### PR TITLE
initial monochrome icon for #26280

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+<!--  <path-->
+<!--      android:pathData="M78.13,44.28c-1.13,-2.72 -3.43,-5.66 -5.23,-6.59a26.79,26.79 0,0 1,2.64 7.91c-3,-7.34 -7.94,-10.3 -12,-16.74 -0.2,-0.33 -0.41,-0.65 -0.61,-1a5.94,5.94 0,0 1,-0.29 -0.54,4.92 4.92,0 0,1 -0.39,-1 0.07,0.07 0,0 0,-0.05 -0.07h-0.07a19,19 0,0 0,-9 14.46A12.92,12.92 0,0 0,46 43.49a10.031,10.031 0,0 0,-0.68 -0.51,12 12,0 0,1 -0.07,-6.36A19.21,19.21 0,0 0,39 41.46c-1,-1.31 -1,-5.62 -0.9,-6.52a4.39,4.39 0,0 0,-0.87 0.46,19.37 19.37,0 0,0 -2.54,2.18 22.23,22.23 0,0 0,-2.43 2.92,21.88 21.88,0 0,0 -3.5,7.88v0.18a39.159,39.159 0,0 0,-0.26 1.62,0.13 0.13,0 0,1 0,0.06 26.47,26.47 0,0 0,-0.5 3.59L28,54a26,26 0,0 0,51.7 4.41l0.12,-1a26.9,26.9 0,0 0,-1.69 -13.13zM48.13,64.66l0.36,0.18zM54.13,48.96zM75.6,45.65z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:startY="34.731655"-->
+<!--          android:startX="73.6671"-->
+<!--          android:endY="77.194664"-->
+<!--          android:endX="32.80596"-->
+<!--          android:type="linear">-->
+<!--        <item android:offset="0.05" android:color="#FFFFF44F"/>-->
+<!--        <item android:offset="0.37" android:color="#FFFF980E"/>-->
+<!--        <item android:offset="0.53" android:color="#FFFF3647"/>-->
+<!--        <item android:offset="0.7" android:color="#FFE31587"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M78.13,44.28c-1.13,-2.72 -3.43,-5.66 -5.23,-6.59a26.79,26.79 0,0 1,2.64 7.91,23.55 23.55,0 0,1 -0.81,17.57c-3,6.4 -10.21,13 -21.51,12.65 -12.22,-0.35 -23,-9.41 -25,-21.29a11.22,11.22 0,0 1,0.18 -4.34,19.61 19.61,0 0,0 -0.4,3.64V54a26,26 0,0 0,51.7 4.41l0.12,-1a26.9,26.9 0,0 0,-1.69 -13.13z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="53.746716"-->
+<!--          android:centerX="68.339355"-->
+<!--          android:centerY="37.69"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.13" android:color="#FFFFBD4F"/>-->
+<!--        <item android:offset="0.28" android:color="#FFFF980E"/>-->
+<!--        <item android:offset="0.47" android:color="#FFFF3750"/>-->
+<!--        <item android:offset="0.78" android:color="#FFEB0878"/>-->
+<!--        <item android:offset="0.86" android:color="#FFE50080"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M78.13,44.28c-1.13,-2.72 -3.43,-5.66 -5.23,-6.59a26.79,26.79 0,0 1,2.64 7.91,23.55 23.55,0 0,1 -0.81,17.57c-3,6.4 -10.21,13 -21.51,12.65 -12.22,-0.35 -23,-9.41 -25,-21.29a11.22,11.22 0,0 1,0.18 -4.34,19.61 19.61,0 0,0 -0.4,3.64V54a26,26 0,0 0,51.7 4.41l0.12,-1a26.9,26.9 0,0 0,-1.69 -13.13z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="55.09038"-->
+<!--          android:centerX="48.57382"-->
+<!--          android:centerY="55.002163"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.3" android:color="#FF960E18"/>-->
+<!--        <item android:offset="0.35" android:color="#BCB11927"/>-->
+<!--        <item android:offset="0.43" android:color="#56DB293D"/>-->
+<!--        <item android:offset="0.5" android:color="#16F5334B"/>-->
+<!--        <item android:offset="0.53" android:color="#00FF3750"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M65.47,47.34l0.17,0.12a14.35,14.35 0,0 0,-2.42 -3.15c-8.09,-8.09 -2.12,-17.55 -1.12,-18a19,19 0,0 0,-9 14.46h0.92a13.13,13.13 0,0 1,11.45 6.57z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="29.610003"-->
+<!--          android:centerX="59.1192"-->
+<!--          android:centerY="23.771997"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.13" android:color="#FFFFF44F"/>-->
+<!--        <item android:offset="0.53" android:color="#FFFF980E"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M54.08,49c0,0.65 -2.33,2.88 -3.13,2.88 -7.4,0 -8.6,4.48 -8.6,4.48a11,11 0,0 0,6.13 8.52l0.44,0.21a12.13,12.13 0,0 0,0.76 0.31,11.91 11.91,0 0,0 3.39,0.66c13,0.61 15.49,-15.52 6.13,-20.2a9,9 0,0 1,6.27 1.52,13.13 13.13,0 0,0 -11.4,-6.66h-0.92A12.92,12.92 0,0 0,46 43.49c0.39,0.34 0.84,0.78 1.79,1.71 1.75,1.8 6.28,3.55 6.29,3.8z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="26.21"-->
+<!--          android:centerX="48.315395"-->
+<!--          android:centerY="69.29355"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.35" android:color="#FF3A8EE6"/>-->
+<!--        <item android:offset="0.67" android:color="#FF9059FF"/>-->
+<!--        <item android:offset="1" android:color="#FFC139E6"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M54.08,49c0,0.65 -2.33,2.88 -3.13,2.88 -7.4,0 -8.6,4.48 -8.6,4.48a11,11 0,0 0,6.13 8.52l0.44,0.21a12.13,12.13 0,0 0,0.76 0.31,11.91 11.91,0 0,0 3.39,0.66c13,0.61 15.49,-15.52 6.13,-20.2a9,9 0,0 1,6.27 1.52,13.13 13.13,0 0,0 -11.4,-6.66h-0.92A12.92,12.92 0,0 0,46 43.49c0.39,0.34 0.84,0.78 1.79,1.71 1.75,1.8 6.28,3.55 6.29,3.8z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="13.917509"-->
+<!--          android:centerX="50.381275"-->
+<!--          android:centerY="49.283504"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.21" android:color="#009059FF"/>-->
+<!--        <item android:offset="0.97" android:color="#996E008B"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M44.77,42.62l0.54,0.36a12,12 0,0 1,-0.07 -6.36A19.21,19.21 0,0 0,39 41.46c0.1,0 3.87,-0.07 5.77,1.16z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="18.444002"-->
+<!--          android:centerX="52.251003"-->
+<!--          android:centerY="30.259998"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.1" android:color="#FFFFE226"/>-->
+<!--        <item android:offset="0.79" android:color="#FFFF7139"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M28.24,54.58c2,11.88 12.77,20.94 25,21.29 11.3,0.32 18.52,-6.25 21.51,-12.65a23.55,23.55 0,0 0,0.81 -17.57c0.92,6 -2.15,11.87 -6.94,15.82 -9.34,7.61 -18.28,4.59 -20.09,3.35l-0.38,-0.19c-5.45,-2.6 -7.7,-7.56 -7.22,-11.82A6.67,6.67 0,0 1,34.74 49a9.8,9.8 0,0 1,9.57 -0.38A13,13 0,0 0,54.08 49c0,-0.21 -4.54,-2 -6.3,-3.76 -1,-0.93 -1.4,-1.37 -1.79,-1.71a10.031,10.031 0,0 0,-0.68 -0.51l-0.54,-0.36c-1.9,-1.23 -5.67,-1.16 -5.8,-1.16 -1,-1.31 -1,-5.62 -0.9,-6.52a4.39,4.39 0,0 0,-0.87 0.46,19.37 19.37,0 0,0 -2.54,2.18 22.23,22.23 0,0 0,-2.43 2.92,21.88 21.88,0 0,0 -3.5,7.88c-0.02,0.02 -0.95,4.07 -0.49,6.16z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="89.619446"-->
+<!--          android:centerX="69.60241"-->
+<!--          android:centerY="18.083904"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.11" android:color="#FFFFF44F"/>-->
+<!--        <item android:offset="0.46" android:color="#FFFF980E"/>-->
+<!--        <item android:offset="0.72" android:color="#FFFF3647"/>-->
+<!--        <item android:offset="0.9" android:color="#FFE31587"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M63.22,44.31a14.35,14.35 0,0 1,2.42 3.15l0.39,0.32c5.9,5.44 2.81,13.13 2.58,13.68 4.79,-4 7.86,-9.79 6.94,-15.82 -3,-7.34 -7.94,-10.3 -12,-16.74 -0.2,-0.33 -0.41,-0.65 -0.61,-1a5.94,5.94 0,0 1,-0.29 -0.54,4.92 4.92,0 0,1 -0.39,-1 0.07,0.07 0,0 0,-0.05 -0.07H62.1c-1,0.47 -6.97,9.93 1.12,18.02z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="95.36754"-->
+<!--          android:centerX="-6.7701335"-->
+<!--          android:centerY="37.102222"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0" android:color="#FFFFF44F"/>-->
+<!--        <item android:offset="0.3" android:color="#FFFF980E"/>-->
+<!--        <item android:offset="0.57" android:color="#FFFF3647"/>-->
+<!--        <item android:offset="0.74" android:color="#FFE31587"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M66,47.78l-0.39,-0.32 -0.17,-0.12a9,9 0,0 0,-6.27 -1.52c9.36,4.68 6.85,20.81 -6.13,20.2a11.91,11.91 0,0 1,-3.39 -0.66,12.13 12.13,0 0,1 -0.76,-0.31l-0.44,-0.21c1.81,1.24 10.75,4.26 20.09,-3.35 0.3,-0.58 3.39,-8.27 -2.54,-13.71z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="56.180176"-->
+<!--          android:centerX="52.887726"-->
+<!--          android:centerY="35.519154"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.14" android:color="#FFFFF44F"/>-->
+<!--        <item android:offset="0.48" android:color="#FFFF980E"/>-->
+<!--        <item android:offset="0.66" android:color="#FFFF3647"/>-->
+<!--        <item android:offset="0.9" android:color="#FFE31587"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+<!--  <path-->
+<!--      android:pathData="M42.35,56.32s1.2,-4.48 8.6,-4.48c0.8,0 3.09,-2.23 3.13,-2.88a13,13 0,0 1,-9.77 -0.38,9.8 9.8,0 0,0 -9.57,0.38 6.67,6.67 0,0 0,6.16 3.88c-0.48,4.26 1.77,9.22 7.22,11.82l0.36,0.18a11,11 0,0 1,-6.13 -8.52z">-->
+<!--    <aapt:attr name="android:fillColor">-->
+<!--      <gradient-->
+<!--          android:gradientRadius="60.55354"-->
+<!--          android:centerX="65.548615"-->
+<!--          android:centerY="39.680077"-->
+<!--          android:type="radial">-->
+<!--        <item android:offset="0.09" android:color="#FFFFF44F"/>-->
+<!--        <item android:offset="0.63" android:color="#FFFF980E"/>-->
+<!--      </gradient>-->
+<!--    </aapt:attr>-->
+<!--  </path>-->
+  <path
+      android:pathData="M78.13,44.28c-1.13,-2.72 -3.43,-5.66 -5.23,-6.59a26.79,26.79 0,0 1,2.64 7.91c-3,-7.34 -7.94,-10.3 -12,-16.74 -0.2,-0.33 -0.41,-0.65 -0.61,-1a5.94,5.94 0,0 1,-0.29 -0.54,4.92 4.92,0 0,1 -0.39,-1 0.07,0.07 0,0 0,-0.05 -0.07h-0.07a19,19 0,0 0,-9 14.46h0.92a13.13,13.13 0,0 1,11.4 6.66,9 9,0 0,0 -6.27,-1.52c9.36,4.68 6.85,20.81 -6.13,20.2a11.91,11.91 0,0 1,-3.39 -0.66,12.13 12.13,0 0,1 -0.76,-0.31l-0.44,-0.21 -0.38,-0.19 0.36,0.18a11,11 0,0 1,-6.13 -8.52s1.2,-4.48 8.6,-4.48c0.8,0 3.09,-2.23 3.13,-2.88 0,-0.21 -4.54,-2 -6.3,-3.76 -1,-0.93 -1.4,-1.37 -1.79,-1.71A10.031,10.031 0,0 0,45.27 43a12,12 0,0 1,-0.07 -6.36,19.21 19.21,0 0,0 -6.2,4.82c-1,-1.31 -1,-5.62 -0.9,-6.52a4.39,4.39 0,0 0,-0.87 0.46,19.37 19.37,0 0,0 -2.54,2.18 22.23,22.23 0,0 0,-2.43 2.92,21.88 21.88,0 0,0 -3.5,7.88v0.18a39.815,39.815 0,0 0,-0.3 1.64A31.77,31.77 0,0 0,28 53.83L28,54a26,26 0,0 0,51.7 4.41l0.12,-1a26.9,26.9 0,0 0,-1.69 -13.13zM75.54,45.62z"
+      android:fillColor="#fff">
+  </path>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -5,4 +5,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -5,4 +5,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
This uses the standard firefox ic_launcher_foreground as a monochrome (i.e. themeable) icon by simply removing the globe from it. This is then added in ic_launcher.xml and ic_launcher_round.xml as the <monochrome/> part of the adaptive icon.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
